### PR TITLE
Minify or indent JSON using arg for #51

### DIFF
--- a/data_conversion/Makefile
+++ b/data_conversion/Makefile
@@ -1,6 +1,7 @@
 SHELL := /bin/bash
 
 export PANTHER_VERSION ?= 15.0
+export DEBUG_INDENT ?= 0
 
 %/all: %/full_go_annotated.json %/human_iba_annotations.json %/human_iba_gene_info.json %/taxon_lkp.json
 	echo "Done"
@@ -99,33 +100,25 @@ export PANTHER_VERSION ?= 15.0
 %/goslim_generic.tsv: %/goslim_generic_w_alt_ids.tsv
 	awk '$$2 != ""' $< | cut -f1 | grep GO > $@
 
-.PRECIOUS: %.json
-%.json: %.pretty.json
-	jq -c . $< > $@
+.PRECIOUS: %/human_iba_annotations.json
+%/human_iba_annotations.json: %/resources/gene_association.paint_human.gaf %/resources/goparentchild.tsv %/goslim_generic.tsv %/resources/go_aspects.tsv %/resources/gene.dat
+	python3 iba_exp_refs_to_json.py --debug_indent $(DEBUG_INDENT) -f $*/resources/gene_association.paint_human.gaf resources/annot_human_genes_not_in_families_selected.gaf -o $*/resources/goparentchild.tsv -s $*/goslim_generic.tsv -a $*/resources/go_aspects.tsv -p $*/resources/gene.dat > $@
 
-.PRECIOUS: %/human_iba_annotations.pretty.json
-%/human_iba_annotations.pretty.json: %/resources/gene_association.paint_human.gaf %/resources/goparentchild.tsv %/goslim_generic.tsv %/resources/go_aspects.tsv %/resources/gene.dat
-	python3 iba_exp_refs_to_json.py -f $*/resources/gene_association.paint_human.gaf resources/annot_human_genes_not_in_families_selected.gaf -o $*/resources/goparentchild.tsv -s $*/goslim_generic.tsv -a $*/resources/go_aspects.tsv -p $*/resources/gene.dat > $@
+.PRECIOUS: %/human_iba_gene_info.json
+%/human_iba_gene_info.json: %/resources/gene_association.paint_human.gaf %/resources/gene.dat %/resources/gene_node.dat %/resources/Homo_sapiens.chromosomal_location
+	python3 gene_info_from_gafs.py --debug_indent $(DEBUG_INDENT) -a $*/resources/gene_association.paint_human.gaf resources/annot_human_genes_not_in_families_selected.gaf -g $*/resources/gene.dat -n $*/resources/gene_node.dat -c $*/resources/Homo_sapiens.chromosomal_location > $@
 
-# .PRECIOUS: %/human_iba_gene_info.json
-# %/human_iba_gene_info.json: %/resources/gene_association.paint_human.gaf %/resources/goparentchild.tsv %/goslim_generic.tsv %/resources/go_aspects.tsv %/resources/gene.dat %/resources/Homo_sapiens.chromosomal_location
-# 	python3 iba_exp_refs_to_json.py -f $*/resources/gene_association.paint_human.gaf -o $*/resources/goparentchild.tsv -s $*/goslim_generic.tsv -a $*/resources/go_aspects.tsv -p $*/resources/gene.dat -c $*/resources/Homo_sapiens.chromosomal_location -g > $@
-
-.PRECIOUS: %/human_iba_gene_info.pretty.json
-%/human_iba_gene_info.pretty.json: %/resources/gene_association.paint_human.gaf %/resources/gene.dat %/resources/gene_node.dat %/resources/Homo_sapiens.chromosomal_location
-	python3 gene_info_from_gafs.py -a $*/resources/gene_association.paint_human.gaf resources/annot_human_genes_not_in_families_selected.gaf -g $*/resources/gene.dat -n $*/resources/gene_node.dat -c $*/resources/Homo_sapiens.chromosomal_location > $@
-
-.PRECIOUS: %/taxon_lkp.pretty.json
-%/taxon_lkp.pretty.json: %/resources/species_list.tsv
-	python3 gene_info_taxon_lookup.py -g $*/human_iba_gene_info.json -s $*/resources/species_list.tsv > $@
+.PRECIOUS: %/taxon_lkp.json
+%/taxon_lkp.json: %/resources/species_list.tsv
+	python3 gene_info_taxon_lookup.py --debug_indent $(DEBUG_INDENT) -g $*/human_iba_gene_info.json -s $*/resources/species_list.tsv > $@
 
 .PRECIOUS: %/full_go.json
 %/full_go.json: %/resources/go.obo %/bin/robot
 	$*/bin/robot export --input $*/resources/go.obo --header "ID|LABEL|hasOBONamespace" --format json --export $@
 
-.PRECIOUS: %/full_go_annotated.pretty.json
-%/full_go_annotated.pretty.json: %/goslim_generic.tsv %/full_go.json
-	python3 annotate_is_goslim_json_ontology.py -g $*/goslim_generic.tsv -p $*/full_go.json > $@
+.PRECIOUS: %/full_go_annotated.json
+%/full_go_annotated.json: %/goslim_generic.tsv %/full_go.json
+	python3 annotate_is_goslim_json_ontology.py --debug_indent $(DEBUG_INDENT) -g $*/goslim_generic.tsv -p $*/full_go.json > $@
 
 tests:
 	pytest test.py

--- a/data_conversion/annotate_is_goslim_json_ontology.py
+++ b/data_conversion/annotate_is_goslim_json_ontology.py
@@ -7,6 +7,7 @@ import json
 parser = argparse.ArgumentParser()
 parser.add_argument('-g', '--goslim_term_list', help="Single-col file list of terms in goslim_generic")
 parser.add_argument('-p', '--panther_slim_json')
+parser.add_argument('-d', '--debug_indent', type=int, default=0)
 
 
 if __name__ == "__main__":
@@ -76,4 +77,7 @@ if __name__ == "__main__":
 
     annotated_panther_slim = annotated_panther_slim + other_terms + unknown_terms
 
-    print(json.dumps(annotated_panther_slim, indent=4))
+    if args.debug_indent != 0:
+        print(json.dumps(annotated_panther_slim, indent=args.debug_indent))
+    else:
+        print(json.dumps(annotated_panther_slim, separators=(',', ':')))

--- a/data_conversion/gene_info_from_gafs.py
+++ b/data_conversion/gene_info_from_gafs.py
@@ -12,6 +12,7 @@ parser.add_argument('-g', '--gene_dat')
 parser.add_argument('-n', '--gene_node_dat')
 parser.add_argument('-c', '--genome_coordinates_file', help="If supplied, will be added to gene info. Typically, "
                                                             "a file named Homo_sapiens.chromosomal_location")
+parser.add_argument('-d', '--debug_indent', type=int, default=0)
 
 
 class GeneInfoCollection:
@@ -147,8 +148,11 @@ class GeneInfoCollection:
             gene_infos.append(gene_info_record)
         return gene_infos
 
-    def print_genes_to_json(self):
-        print(json.dumps(self.gene_info_list(), indent=4))
+    def print_genes_to_json(self, debug_indent: int = 0):
+        if debug_indent != 0:
+            print(json.dumps(self.gene_info_list(), indent=debug_indent))
+        else:
+            print(json.dumps(self.gene_info_list(), separators=(',', ':')))
 
 
 if __name__ == "__main__":
@@ -161,4 +165,4 @@ if __name__ == "__main__":
     gene_info_collection.fill_in_gene_panther_family(args.gene_node_dat)
     gene_info_collection.fill_in_genome_coordinates(args.genome_coordinates_file)
 
-    gene_info_collection.print_genes_to_json()
+    gene_info_collection.print_genes_to_json(args.debug_indent)

--- a/data_conversion/gene_info_taxon_lookup.py
+++ b/data_conversion/gene_info_taxon_lookup.py
@@ -6,6 +6,7 @@ import csv
 parser = argparse.ArgumentParser()
 parser.add_argument('-g', '--gene_info_json')
 parser.add_argument('-s', '--species_list_tsv')
+parser.add_argument('-d', '--debug_indent', type=int, default=0)
 
 
 if __name__ == "__main__":
@@ -36,4 +37,7 @@ if __name__ == "__main__":
                 }
                 taxon_objs.append(taxon_obj)
 
-    print(json.dumps(taxon_objs, indent=4))
+    if args.debug_indent != 0:
+        print(json.dumps(taxon_objs, indent=args.debug_indent))
+    else:
+        print(json.dumps(taxon_objs, separators=(',', ':')))


### PR DESCRIPTION
To decrease the number of files produced (i.e., `.pretty.json` vs `.json`), this switches the method of minifying JSON output from `jq` to passing a Makefile (`DEBUG_INDENT`) and python argument `--debug_indent` into the scripts.

This change is part of #51.